### PR TITLE
chore: Remove signoff requirements check for pull requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,2 @@
 # Automatically request reviews from the synapse-core and dendrite-core teams when a pull request comes in.
-* @matrix-org/synapse-core @matrix-org/dendrite-core
-
-# For modifications to complement internals, also directly request review from Kegan.
-/build/ @matrix-org/synapse-core @matrix-org/dendrite-core @kegsay
-/cmd/ @matrix-org/synapse-core @matrix-org/dendrite-core @kegsay
-/internal/ @matrix-org/synapse-core @matrix-org/dendrite-core @kegsay
-/runtime/ @matrix-org/synapse-core @matrix-org/dendrite-core @kegsay
+* @famedly/matrix-team

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,0 @@
-### Pull Request Checklist
-
-- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
-

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         include:
           - homeserver: Synapse
-            repo: element-hq/synapse
+            repo: famedly/synapse
             tags: synapse_blacklist
             packages: ./tests/msc3874 ./tests/msc3902 ./tests/msc4306
             env: "COMPLEMENT_ENABLE_DIRTY_RUNS=1 COMPLEMENT_SHARE_ENV_PREFIX=PASS_ PASS_SYNAPSE_COMPLEMENT_DATABASE=sqlite"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,10 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  check-signoff:
-    if: "github.event_name == 'pull_request'"
-    uses: "matrix-org/backend-meta/.github/workflows/sign-off.yml@v2"
-
   complement-internal:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We don't require signoffs on commits, but instead need verified commits. Remove that part of the CI workflow and remove the pull request template file for now, since that was the only thing in it